### PR TITLE
Makes move.poke valid JSON

### DIFF
--- a/move.poke
+++ b/move.poke
@@ -1,4 +1,4 @@
-﻿[
+[
     {"name":"Absorb","name_de":"Absorber","name_fr":"Vol-Vie","name_ja":"すいとる (Suitoru)","type":11,"category":"Special","power":"20","accuracy":"100","pp":"25","tm":"0","probability":"0","description":"User recovers half the HP inflicted on opponent."},
     {"name":"Acid Armor","name_de":"Säurepanzer","name_fr":"Acidarmure","name_ja":"とける (Tokeru)","type":3,"category":"Status","power":"0","accuracy":"0","pp":"40","tm":"0","probability":"0","description":"Sharply raises user's Defense."},
     {"name":"Acid Spray","name_de":"Säurespeier","name_fr":"Bombe Acide","name_ja":"アシッドボム (Acid Bomb)","type":3,"category":"Special","power":"40","accuracy":"100","pp":"20","tm":"0","probability":"100","description":"Sharply lowers opponent's Special Defense."},


### PR DESCRIPTION
There was a non-printing Unicode character at the beginning of move.poke that was causing problems when interpreting the file as JSON.